### PR TITLE
query -> q for short-circuiting query

### DIFF
--- a/src/jet/query.clj
+++ b/src/jet/query.clj
@@ -51,7 +51,7 @@
 (defn query
   [x q]
   (cond
-    (not query) nil
+    (not q) nil
     (vector? q) (if-let [next-op (first q)]
                   (query (query x next-op) (vec (rest q)))
                   x)

--- a/test/jet/query_test.clj
+++ b/test/jet/query_test.clj
@@ -4,6 +4,7 @@
    [jet.query :refer [query]]))
 
 (deftest query-test
+  (is (= nil (query [] false)))
   (is (= '1 (query {:a 1 :b 2} :a)))
   (is (= '1 (query {1 1} 1)))
   (is (= '1 (query {"1" 1} "1")))


### PR DESCRIPTION
I think this is what you meant ... ?