### PR TITLE
Add CSV and TSV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Clojars Project](https://img.shields.io/clojars/v/borkdude/jet.svg)](https://clojars.org/borkdude/jet)
 [![cljdoc badge](https://cljdoc.org/badge/borkdude/jet)](https://cljdoc.org/d/borkdude/jet/CURRENT)
 
-CLI to transform between JSON, EDN and Transit, powered with a minimal query
-language.
+CLI to transform between JSON, EDN, Transit, and CSV, powered with a minimal
+query language.
 
 ## Quickstart
 
@@ -17,10 +17,11 @@ $ echo '{:a 1}' | jet --to json
 
 ## Rationale
 
-This is a command line tool to transform between JSON, EDN and Transit, powered
-with a minimal query language. It runs as a GraalVM binary with fast startup time
-which makes it suited for shell scripting. It comes with a query language to do
-intermediate transformation. It may seem familiar to users of `jq`.
+This is a command line tool to transform between JSON, EDN, Transit, and CSV,
+powered with a minimal query language. It runs as a GraalVM binary with fast
+startup time which makes it suited for shell scripting. It comes with a query
+language to do intermediate transformation. It may seem familiar to users of
+`jq`.
 
 ## Installation
 
@@ -76,8 +77,8 @@ $ echo '["^ ","~:a",1]' | lein jet --from transit --to edn
 
 `jet` supports the following options:
 
-   - `--from`: `edn`, `transit` or `json`, defaults to `edn`
-   - `--to`: `edn`, `transit` or `json`, defaults to `edn`
+   - `--from`: `edn`, `transit`, `json`, `csv`, or `tsv`, defaults to `edn`
+   - `--to`: `edn`, `transit` or `json`, `csv`, or `tsv`, defaults to `edn`
    - `--keywordize [ <key-fn> ]`: if present, keywordizes JSON keys. The default
      transformation function is `keyword` unless you provide your own.
    - `--pretty`: if present, pretty-prints JSON and EDN output.

--- a/src/jet/csv.clj
+++ b/src/jet/csv.clj
@@ -1,0 +1,148 @@
+;; Copyright (c) Jonas Enlund. All rights reserved.  The use and
+;; distribution terms for this software are covered by the Eclipse
+;; Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this
+;; distribution.  By using this software in any fashion, you are
+;; agreeing to be bound by the terms of this license.  You must not
+;; remove this notice, or any other, from this software.
+
+(ns ^{:author "Jonas Enlund"
+      :doc "Reading and writing comma separated values. Forked from
+    clojure/data.csv to expose the private #'read-record function, and to
+    address some reflection warnings."}
+    jet.csv
+  (:require [clojure.string :as str])
+  (:import (java.io PushbackReader Reader Writer StringReader EOFException)))
+
+(set! *warn-on-reflection* true)
+
+;; Reading
+
+(def ^{:private true} lf  (int \newline))
+(def ^{:private true} cr  (int \return))
+(def ^{:private true} eof -1)
+
+(defn- read-quoted-cell [^PushbackReader reader ^StringBuilder sb sep quote]
+  (loop [ch (.read reader)]
+    (condp == ch
+      quote (let [next-ch (.read reader)]
+              (condp == next-ch
+                quote (do (.append sb (char quote))
+                          (recur (.read reader)))
+                sep :sep
+                lf  :eol
+                cr  (let [next-next-ch (.read reader)]
+                      (when (not= next-next-ch lf)
+                        (.unread reader next-next-ch))
+                      :eol)
+                eof :eof
+                (throw (Exception. ^String (format "CSV error (unexpected character: %c)" next-ch)))))
+      eof (throw (EOFException. "CSV error (unexpected end of file)"))
+      (do (.append sb (char ch))
+          (recur (.read reader))))))
+
+(defn- read-cell [^PushbackReader reader ^StringBuilder sb sep quote]
+  (let [first-ch (.read reader)]
+    (if (== first-ch quote)
+      (read-quoted-cell reader sb sep quote)
+      (loop [ch first-ch]
+        (condp == ch
+          sep :sep
+          lf  :eol
+          cr (let [next-ch (.read reader)]
+               (when (not= next-ch lf)
+                 (.unread reader next-ch))
+               :eol)
+          eof :eof
+          (do (.append sb (char ch))
+              (recur (.read reader))))))))
+
+(defn read-record [reader sep quote]
+  (loop [record (transient [])]
+    (let [cell (StringBuilder.)
+          sentinel (read-cell reader cell sep quote)]
+      (if (= sentinel :sep)
+        (recur (conj! record (str cell)))
+        [(persistent! (conj! record (str cell))) sentinel]))))
+
+(defprotocol Read-CSV-From
+  (read-csv-from [input sep quote]))
+
+(extend-protocol Read-CSV-From
+  String
+  (read-csv-from [s sep quote]
+    (read-csv-from (PushbackReader. (StringReader. s)) sep quote))
+
+  Reader
+  (read-csv-from [reader sep quote]
+    (read-csv-from (PushbackReader. reader) sep quote))
+
+  PushbackReader
+  (read-csv-from [reader sep quote]
+    (lazy-seq
+     (let [[record sentinel] (read-record reader sep quote)]
+       (case sentinel
+	       :eol (cons record (read-csv-from reader sep quote))
+	       :eof (when-not (= record [""])
+		            (cons record nil)))))))
+
+(defn read-csv
+  "Reads CSV-data from input (String or java.io.Reader) into a lazy
+  sequence of vectors.
+
+   Valid options are
+     :separator (default \\,)
+     :quote (default \\\")"
+  [input & options]
+  (let [{:keys [separator quote] :or {separator \, quote \"}} options]
+    (read-csv-from input (int separator) (int quote))))
+
+
+;; Writing
+
+(defn- write-cell [^Writer writer obj sep quote quote?]
+  (let [string (str obj)
+	      must-quote (quote? string)]
+    (when must-quote (.write writer (int quote)))
+    (.write writer (if must-quote
+		                 (str/escape string
+				                         {quote (str quote quote)})
+		                 string))
+    (when must-quote (.write writer (int quote)))))
+
+(defn write-record [^Writer writer record sep quote quote?]
+  (loop [record record]
+    (when-first [cell record]
+      (write-cell writer cell sep quote quote?)
+      (when-let [more (next record)]
+	      (.write writer (int sep))
+	      (recur more)))))
+
+(defn- write-csv*
+  [^Writer writer records sep quote quote? ^String newline]
+  (loop [records records]
+    (when-first [record records]
+      (write-record writer record sep quote quote?)
+      (.write writer newline)
+      (recur (next records)))))
+
+(defn write-csv
+  "Writes data to writer in CSV-format.
+
+   Valid options are
+     :separator (Default \\,)
+     :quote (Default \\\")
+     :quote? (A predicate function which determines if a string should be quoted. Defaults to quoting only when necessary.)
+     :newline (:lf (default) or :cr+lf)"
+  [writer data & options]
+  (let [opts (apply hash-map options)
+        separator (or (:separator opts) \,)
+        quote (or (:quote opts) \")
+        quote? (or (:quote? opts) #(some #{separator quote \return \newline} %))
+        newline (or (:newline opts) :lf)]
+    (write-csv* writer
+		            data
+		            separator
+		            quote
+                quote?
+		            ({:lf "\n" :cr+lf "\r\n"} newline))))

--- a/src/jet/main.clj
+++ b/src/jet/main.clj
@@ -74,8 +74,8 @@
   (println "
   --help: print this help text.
   --version: print the current version of jet.
-  --from: edn, transit or json, defaults to edn.
-  --to: edn, transit or json, defaults to edn.
+  --from: edn, transit, json, csv, or tsv, defaults to edn.
+  --to: edn, transit, json, csv, or tsv, defaults to edn.
   --keywordize [ <key-fn> ]: if present, keywordizes JSON keys. The default transformation function is keyword unless you provide your own.
   --pretty: if present, pretty-prints JSON and EDN output.
   --query: given a jet-lang query, transforms input. See doc/query.md for more.
@@ -95,10 +95,14 @@
           (let [reader (case from
                          :json (formats/json-parser)
                          :transit (formats/transit-reader)
+                         :csv (formats/push-back-reader)
+                         :tsv (formats/push-back-reader)
                          :edn nil)
                 next-val (case from
                            :edn #(formats/parse-edn *in*)
                            :json #(formats/parse-json reader keywordize)
+                           :csv #(formats/parse-csv reader)
+                           :tsv #(formats/parse-tsv reader)
                            :transit #(formats/parse-transit reader))
                 collected (when collect (vec (take-while #(not= % ::formats/EOF)
                                                          (repeatedly next-val))))]
@@ -110,7 +114,9 @@
                     (case to
                       :edn (println (formats/generate-edn input pretty))
                       :json (println (formats/generate-json input pretty))
-                      :transit (println (formats/generate-transit input))))
+                      :transit (println (formats/generate-transit input))
+                      :csv (println (formats/generate-csv input))
+                      :tsv (println (formats/generate-tsv input))))
                   (when-not collect (recur)))))))))
 
 ;;;; Scratch

--- a/test/jet/main_test.clj
+++ b/test/jet/main_test.clj
@@ -45,7 +45,13 @@
   (testing "from and to default to edn"
     (is (= "1\n" (jet "{:a 1 :b 2}" "--query" ":a"))))
   (testing "implicity wrapping multiple queries"
-    (is (= "1\n" (jet "{:a {:b 1}}" "--query" ":a :b")))))
+    (is (= "1\n" (jet "{:a {:b 1}}" "--query" ":a :b"))))
+  (testing "csv"
+    (is (= "[\"1\" \"2\" \"3\"]\n" (jet "1,2,3" "--from" "csv")))
+    (is (= "1,2,\"hello,world\"\n" (jet "[1 2 \"hello,world\"]" "--to" "csv"))))
+  (testing "tsv"
+    (is (= "[\"1\" \"2\" \"3\"]\n" (jet "1\t2\t3" "--from" "tsv")))
+    (is (= "1\t2\thello,world\n" (jet "[1 2 \"hello,world\"]" "--to" "tsv")))))
 
 (deftest interactive-test
   (testing "passing correct query will please jeti"


### PR DESCRIPTION
Add support in --from / --to / :jeti/slurp and :jeti/spit

Vendors clojure.data.csv as jet.csv to expose some private functions and address
some reflection warnings.

Closes #52 

Open questions:

- [ ] Maybe it would be best if `--csv-opts` just passed through the options to `clojure.data.csv` as much as possible and not try to hide that we are using it. This is consistent with how `--keywordize` behaves, we pass through the argument to `cheshire` (`true` or a function which is evaluated by sci). Thoughts? - @borkdude 

- [ ] I think it makes more sense if jet handles one CSV document as one value instead of treating one CSV row as one input value (so what it currently does with this PR + --collect). 
People can do something like cat foo.csv | jet --from csv > /tmp/foo.edn.csv and then slurp+edn/read-string it from some other program. I don't really see what the practical use case is for having the current behavior. Do you?  - @borkdude

- [ ] I can also see it being useful to get back a collection of maps instead of vectors of vectors, like e.g. https://csvkit.readthedocs.io/en/latest/ does. What do you think? - @borkdude 