### PR TITLE
Added POSIX style flags, with single letters

### DIFF
--- a/src/jet/main.clj
+++ b/src/jet/main.clj
@@ -18,7 +18,7 @@
                     opts-map {}
                     current-opt nil]
                (if-let [opt (first options)]
-                 (if (starts-with? opt "--")
+                 (if (starts-with? opt "-")
                    (recur (rest options)
                           (assoc opts-map opt [])
                           opt)
@@ -26,23 +26,33 @@
                           (update opts-map current-opt conj opt)
                           current-opt))
                  opts-map))
-        from (some-> (get opts "--from") first keyword)
-        to (some-> (get opts "--to") first keyword)
-        keywordize (when-let [k (get opts "--keywordize")]
+        from (some-> (or (get opts "--from")
+                         (get opts "-f")) first keyword)
+        to (some-> (or (get opts "--to")
+                       (get opts "-t")) first keyword)
+        keywordize (when-let [k (or (get opts "--keywordize")
+                                    (get opts "-k"))]
                      (if (empty? k) true
                          (let [f (first k)]
-                             (= "true" f) true
-                             (= "false" f) false
-                             :else (eval-string f))))
-        version (boolean (get opts "--version"))
-        pretty (boolean (get opts "--pretty"))
-        query (first (get opts "--query"))
-        interactive (get opts "--interactive")
-        collect (boolean (get opts "--collect"))
-        edn-reader-opts (let [opts (first (get opts "--edn-reader-opts"))]
+                           (= "true" f) true
+                           (= "false" f) false
+                           :else (eval-string f))))
+        version (boolean (or (get opts "--version")
+                             (get opts "-v")))
+        pretty (boolean (or (get opts "--pretty")
+                            (get opts "-p")))
+        query (first (or (get opts "--query")
+                         (get opts "-q")))
+        interactive (or (get opts "--interactive")
+                        (get opts "-i"))
+        collect (boolean (or (get opts "--collect")
+                             (get opts "-c")))
+        edn-reader-opts (let [opts (or (first (get opts "--edn-reader-opts"))
+                                       (first (get opts "-e")))]
                           (when opts
                             (eval-string opts)))
-        help (boolean (get opts "--help"))]
+        help (boolean (or (get opts "--help")
+                          (get opts "-h")))]
     {:from (or from :edn)
      :to (or to :edn)
      :keywordize keywordize
@@ -66,7 +76,7 @@
 (defn get-usage
   "Gets the usage of the tool"
   []
-  (str "Usage: jet [ --from <format> ] [ --to <format> ] [ --keywordize [ <key-fn> ] ] [ --pretty ] [ --edn-reader-opts ] [--query <query> ] [ --collect ] | [ --interactive <cmd> ]"))
+  (str "Usage: jet [ -f, --from <format> ] [ -t, --to <format> ] [ -k, --keywordize [ <key-fn> ] ] [ -p, --pretty ] [ -e, --edn-reader-opts ] [ -q, --query <query> ] [ -c, --collect ] | [ -i, --interactive <cmd> ]"))
 
 (defn print-help
   "Prints the help text"
@@ -75,16 +85,16 @@
   (println)
   (println (get-usage))
   (println "
-  --help: print this help text.
-  --version: print the current version of jet.
-  --from: edn, transit or json, defaults to edn.
-  --to: edn, transit or json, defaults to edn.
-  --keywordize [ <key-fn> ]: if present, keywordizes JSON keys. The default transformation function is keyword unless you provide your own.
-  --pretty: if present, pretty-prints JSON and EDN output.
-  --edn-reader-opts: options passed to the EDN reader.
-  --query: given a jet-lang query, transforms input. See doc/query.md for more.
-  --collect: given separate values, collects them in a vector.
-  --interactive [ cmd ]: if present, starts an interactive shell. An initial command may be provided. See README.md for more.")
+  -h, --help: print this help text.
+  -v, --version: print the current version of jet.
+  -f, --from: edn, transit or json, defaults to edn.
+  -t, --to: edn, transit or json, defaults to edn.
+  -k, --keywordize [ <key-fn> ]: if present, keywordizes JSON keys. The default transformation function is keyword unless you provide your own.
+  -p, --pretty: if present, pretty-prints JSON and EDN output.
+  -e, --edn-reader-opts: options passed to the EDN reader.
+  -q, --query: given a jet-lang query, transforms input. See doc/query.md for more.
+  -c, --collect: given separate values, collects them in a vector.
+  -i, --interactive [ cmd ]: if present, starts an interactive shell. An initial command may be provided. See README.md for more.")
   (println))
 
 (defn -main

--- a/test/jet/main_test.clj
+++ b/test/jet/main_test.clj
@@ -5,10 +5,15 @@
    [clojure.string :as str]))
 
 (deftest main-test
-  (is (= "{\"a\" 1}\n"
-         (jet "{\"a\": 1}"
-              "--from" "json"
-              "--to" "edn")))
+  (let [result "{\"a\" 1}\n"]
+    (is (= result
+           (jet "{\"a\": 1}"
+                "--from" "json"
+                "--to" "edn")))
+    (is (= result
+           (jet "{\"a\": 1}"
+                "-f" "json"
+                "-t" "edn"))))
   (is (= "{:a 1}\n"
          (jet "{\"a\": 1}"
               "--from" "json"
@@ -36,16 +41,24 @@
               "--from" "transit"
               "--to" "json")))
   (testing "pretty printing"
-    (is (= "{\n  \"a\" : [ {\n    \"b\" : {\n      \"c\" : \"d\"\n    }\n  } ]\n}\n"
-           (jet "{:a [{:b {:c :d}}]}" "--from" "edn" "--to" "json" "--pretty")))
-    (is (= "{:a [{:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}]}\n"
-           (jet "{:a [{:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}}]}" "--from" "edn" "--to" "edn" "--pretty"))))
-  (testing "query"
-    (is (= "1\n" (jet "{:a 1 :b 2}" "--from" "edn" "--to" "edn" "--query" ":a"))))
-  (testing "from and to default to edn"
-    (is (= "1\n" (jet "{:a 1 :b 2}" "--query" ":a"))))
-  (testing "implicity wrapping multiple queries"
-    (is (= "1\n" (jet "{:a {:b 1}}" "--query" ":a :b")))))
+    (let [result "{\n  \"a\" : [ {\n    \"b\" : {\n      \"c\" : \"d\"\n    }\n  } ]\n}\n"
+          pretty-result "{:a [{:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}\n     {:b {:c :d}}]}\n"]
+      (is (= result (jet "{:a [{:b {:c :d}}]}" "--from" "edn" "--to" "json" "--pretty")))
+      (is (= result (jet "{:a [{:b {:c :d}}]}" "-f" "edn" "-t" "json" "-p")))
+      (is (= pretty-result
+             (jet "{:a [{:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}}]}" "--from" "edn" "--to" "edn" "--pretty")))
+      (is (= pretty-result
+             (jet "{:a [{:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}} {:b {:c :d}}]}" "-f" "edn" "-t" "edn" "-p")))))
+  (let [result "1\n"]
+    (testing "query"
+      (is (= result (jet "{:a 1 :b 2}" "--from" "edn" "--to" "edn" "--query" ":a")))
+      (is (= result (jet "{:a 1 :b 2}" "-f" "edn" "-t" "edn" "-q" ":a"))))
+    (testing "from and to default to edn"
+      (is (= result (jet "{:a 1 :b 2}" "--query" ":a")))
+      (is (= result (jet "{:a 1 :b 2}" "-q" ":a"))))
+    (testing "implicity wrapping multiple queries"
+      (is (= result (jet "{:a {:b 1}}" "--query" ":a :b")))
+      (is (= result (jet "{:a {:b 1}}" "-q" ":a :b"))))))
 
 (deftest interactive-test
   (testing "passing correct query will please jeti"
@@ -66,17 +79,26 @@
 
 (deftest stream-test
   (is (= "2\n3\n4\n" (jet "2 3 4" "--from" "edn" "--to" "edn")))
+  (is (= "2\n3\n4\n" (jet "2 3 4" "-f" "edn" "-t" "edn")))
   (is (= "2\n3\n4\n" (jet "{:x 2} {:x 3} {:x 4}" "--query" ":x")))
+  (is (= "2\n3\n4\n" (jet "{:x 2} {:x 3} {:x 4}" "-q" ":x")))
   (is (= "2\n3\n4\n" (jet "{\"a\":2} {\"a\":3} {\"a\":4}" "--from" "json" "--keywordize" "--query" ":a")))
-  (is (= "2\n3\n4\n" (jet "[\"^ \",\"~:a\",2] [\"^ \",\"~:a\",3] [\"^ \",\"~:a\",4]" "--from" "transit" "--query" ":a"))))
+  (is (= "2\n3\n4\n" (jet "{\"a\":2} {\"a\":3} {\"a\":4}" "-f" "json" "-k" "-q" ":a")))
+  (is (= "2\n3\n4\n" (jet "[\"^ \",\"~:a\",2] [\"^ \",\"~:a\",3] [\"^ \",\"~:a\",4]" "--from" "transit" "--query" ":a")))
+  (is (= "2\n3\n4\n" (jet "[\"^ \",\"~:a\",2] [\"^ \",\"~:a\",3] [\"^ \",\"~:a\",4]" "-f" "transit" "-q" ":a"))))
 
 (deftest collect-test
-  (is (= "[{:x 2} {:x 3} {:x 4}]\n" (jet "{:x 2} {:x 3} {:x 4}" "--collect"))))
+  (is (= "[{:x 2} {:x 3} {:x 4}]\n" (jet "{:x 2} {:x 3} {:x 4}" "--collect")))
+  (is (= "[{:x 2} {:x 3} {:x 4}]\n" (jet "{:x 2} {:x 3} {:x 4}" "-c"))))
 
 (deftest key-fn-test
   (is (= "[{:x 2} {:x 3} {:x 4}]\n"
-         (jet "{\" x \": 2} {\" x \": 3} {\" x \": 4}" "--collect" "--from" "json" "--keywordize" "(comp keyword str/trim)"))))
+         (jet "{\" x \": 2} {\" x \": 3} {\" x \": 4}" "--collect" "--from" "json" "--keywordize" "(comp keyword str/trim)")))
+  (is (= "[{:x 2} {:x 3} {:x 4}]\n"
+         (jet "{\" x \": 2} {\" x \": 3} {\" x \": 4}" "-c" "-f" "json" "-k" "(comp keyword str/trim)"))))
 
 (deftest edn-reader-opts-test
   (is (= "#foo {:a 1}\n" (jet "#foo{:a 1}" "--edn-reader-opts" "{:default tagged-literal}")))
-  (is (= "[:foo {:a 1}]\n" (jet "#foo{:a 1}" "--edn-reader-opts" "{:readers {'foo (fn [x] [:foo x])}}"))))
+  (is (= "#foo {:a 1}\n" (jet "#foo{:a 1}" "-e" "{:default tagged-literal}")))
+  (is (= "[:foo {:a 1}]\n" (jet "#foo{:a 1}" "--edn-reader-opts" "{:readers {'foo (fn [x] [:foo x])}}")))
+  (is (= "[:foo {:a 1}]\n" (jet "#foo{:a 1}" "-e" "{:readers {'foo (fn [x] [:foo x])}}"))))


### PR DESCRIPTION
## **tl;dr** 
> this is just a start of a discussion, and I figured that showing you the code would be more meaningful than just opening an issue, because everybody has ideas...

## PR apologia

I love `jet` and I wish that I added it earlier to my arsenal.

Seeing how you have to type the long switches like

```
 echo '["^ ","~:a",1]' | jet --from transit --to edn
```

I thought that this would be more convenient:

```
 echo '["^ ","~:a",1]' | jet -f transit -t edn
```

So I went ahead and abbreviated all the flags to single letter equivalent and added the tests to show that both styles of flags work.

But before you go ahead and merge this:

1. What do you think of this change? Is this something that would be a good thing to have?
2. If you're happy with this change, I suppose I should also update the README to show the short switches in action?
3. If you do like the short switches, do you think that short versions should be even more brief? For example, should we go with the choices I made in this PR? Or should we maybe add an option like `-T` to be equivalent to `-f transit`? And `-E` to be equivalent to `-t edn`?
4. Am I "thinking too hard" here?

Let me know what you think, thanks :)

## This is my "official" reasoning

Added them because the flags with double hyphens followed by a word,
e.g.

    --foo

are a GNU-ism. Whereas the single letter flags are POSIX
recommendation, see:
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html

That is the official blurb, the real motivation was that since this is
a CLI tool, it would be much quicker to type single letter flags than
the double hyphen plus a word flags.