### PR TITLE
Updated Xcode version to the latest stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           destination: release
   buildmac:
     macos:
-      xcode: "9.0"
+      xcode: "12.4.0"
     environment:
       GRAALVM_HOME: /Users/distiller/graalvm-ce-java8-19.3.1/Contents/Home
       JET_PLATFORM: macos # used in release script


### PR DESCRIPTION
The CI run failed with this message:

    failed to create host: Image xcode:9.0 is not supported

Figured that going with the latest stable won't hurt, since the above
Xcode version is no longer supported on CircleCI.