### PR TITLE
Added -C for --collect

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ echo '["^ ","~:a",1]' | lein jet --from transit --to edn
    - `--edn-reader-opts`: options passed to the EDN reader.
    - `-f`, `--func`: a single-arg Clojure function that transforms input.
    - `-q`, `--query`: given a jet-lang query, transforms input. See [jet-lang docs](doc/query.md).
-   - `--collect`: given separate values, collects them in a vector.
+   - `-C`, `--collect`: given separate values, collects them in a vector.
    - `-v`, `--version`: if present, prints current version of `jet` and exits.
    - `--interactive [ cmd ]`: if present, starts an interactive shell. An
      initial command may be provided. See [here](#interactive-shell).

--- a/src/jet/main.clj
+++ b/src/jet/main.clj
@@ -45,7 +45,8 @@
         query (first (or (get opts "--query")
                          (get opts "-q")))
         interactive (get opts "--interactive")
-        collect (boolean (get opts "--collect"))
+        collect (boolean (or (get opts "--collect")
+                             (get opts "-C")))
         edn-reader-opts (let [opts (first (get opts "--edn-reader-opts"))]
                           (if opts
                             (eval-string opts)
@@ -89,7 +90,7 @@
   -f, --func: a single-arg Clojure function that transforms input.
   --edn-reader-opts: options passed to the EDN reader.
   -q, --query: given a jet-lang query, transforms input. See doc/query.md for more.
-  --collect: given separate values, collects them in a vector.
+  -C, --collect: given separate values, collects them in a vector.
   --interactive [ cmd ]: if present, starts an interactive shell. An initial command may be provided. See README.md for more.")
   (println))
 

--- a/test/jet/parse_opts_test.clj
+++ b/test/jet/parse_opts_test.clj
@@ -25,6 +25,10 @@
     (is (nil? (:edn-reader-opts (parse-opts '("--edn-reader-opts" "nil"))))))
   (testing "interactive"
     (is (true? (:interactive (parse-opts '("--interactive"))))))
+  (opt-test {:opt :collect
+             :short-opt '("-C")
+             :long-opt '("--collect")
+             :outcome true})
   (opt-test {:opt :from
              :short-opt '("-i" "json")
              :long-opt '("--from" "json")


### PR DESCRIPTION
Since `-c` is potentially going to be used for `--colorise` option, I
figure that `-C` might be good, shorter alternative to `--collect`.

If you don't like `-C`, please feel free to suggest another alternative.
Thanks