### PR TITLE
introducing tools.cli

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
             :url "http://opensource.org/licenses/eclipse-1.0.php"}
   :source-paths ["src"]
   :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/tools.cli "1.0.206"]
                  [com.cognitect/transit-clj "0.8.319"]
                  [cheshire "5.9.0"]
                  [fipp "0.6.22"]

--- a/test/jet/main_test.clj
+++ b/test/jet/main_test.clj
@@ -53,16 +53,16 @@
                  (jet (str/join "\n" [{:a 1} "Y" :a "Y"]) "--interactive"))))
   (testing "passing --interactive arg as edn"
     (is (re-find #"[0-9a-f]{4}> 1"
-                 (jet (str/join "\n" ["Y" :a "Y"]) "--interactive" "{:a 1}"))))
+                 (jet (str/join "\n" ["Y" :a "Y"]) "--interactive-cmd" "{:a 1}"))))
   (testing "passing --interactive arg as edn"
     (is (re-find #"[0-9a-f]{4}> 1"
-                 (jet (str/join "\n" ["Y" :a "Y"]) "--interactive" ":jeti/set-val {:a 1}"))))
+                 (jet (str/join "\n" ["Y" :a "Y"]) "--interactive-cmd" ":jeti/set-val {:a 1}"))))
   (testing "slurping json file"
     (is (re-find #"[0-9a-f]{4}> 30"
-                 (jet (str/join "\n" ["Y" "count" "Y"]) "--interactive" ":jeti/slurp test/data/commits.json {:format :json}"))))
+                 (jet (str/join "\n" ["Y" "count" "Y"]) "--interactive-cmd" ":jeti/slurp test/data/commits.json {:format :json}"))))
   (testing "jeti doesn't get stuck in a loop and executes the command only once"
     (is (re-find #"Available commands"
-                 (jet "" "--interactive" ":jeti/help")))))
+                 (jet "" "--interactive-cmd" ":jeti/help")))))
 
 (deftest stream-test
   (is (= "2\n3\n4\n" (jet "2 3 4" "--from" "edn" "--to" "edn")))
@@ -75,7 +75,7 @@
 
 (deftest key-fn-test
   (is (= "[{:x 2} {:x 3} {:x 4}]\n"
-         (jet "{\" x \": 2} {\" x \": 3} {\" x \": 4}" "--collect" "--from" "json" "--keywordize" "(comp keyword str/trim)"))))
+         (jet "{\" x \": 2} {\" x \": 3} {\" x \": 4}" "--collect" "--from" "json" "--keywordize-fn" "(comp keyword str/trim)"))))
 
 (deftest edn-reader-opts-test
   (is (= "#foo {:a 1}\n" (jet "#foo{:a 1}" "--edn-reader-opts" "{:default tagged-literal}")))

--- a/test/jet/parse_opts_test.clj
+++ b/test/jet/parse_opts_test.clj
@@ -37,10 +37,10 @@
              :short-opt '("-o" "json")
              :long-opt '("--to" "json")
              :outcome :json})
-  (opt-test {:opt :query
-             :short-opt '("-q")
-             :long-opt '("--query")
-             :outcome nil})
+  (opt-test {:opt       :query
+             :short-opt '("-q" ":a")
+             :long-opt  '("--query" ":a")
+             :outcome   [:a]})
   (opt-test {:opt :version
              :short-opt '("-v")
              :long-opt '("--version")
@@ -58,6 +58,6 @@
              :long-opt '("--keywordize")
              :outcome true})
   (opt-test {:opt :func
-             :short-opt '("-f" nil)
-             :long-opt '("--func" nil)
-             :outcome nil}))
+             :short-opt '("-f" "nil")
+             :long-opt '("--func" "nil")
+             :outcome "nil"}))


### PR DESCRIPTION
I wanted to take a stab at #89.

- realized though that`tools.cli` can't handle options that have _optional_ arguments, so no way to handle both `--keywordize` and `--keywordize keyword`.
For the sake of argument, introduced `--keywordize-fn` and `--interactive-cmd` which have required arguments, and left `--keywordize` and `--interactive` as boolean options.
- replaced help text with the generated summary. 

Let me know if it worth putting more effort into this. Thanks!