### PR TITLE
Add uberjar release functionality to CI script

### DIFF
--- a/.circleci/script/release
+++ b/.circleci/script/release
@@ -5,6 +5,13 @@ mkdir -p /tmp/release
 cp jet /tmp/release
 VERSION=$(cat resources/JET_VERSION)
 
+# release jar, adapted from https://github.com/clj-kondo/clj-kondo/blob/master/.circleci/script/release
+
+if [[ "$JET_PLATFORM" = "linux" ]]; then
+    jar="target/jet-$VERSION-standalone.jar"
+    cp "$jar" /tmp/release
+fi
+
 cd /tmp/release
 
 ## release binary as zip archive


### PR DESCRIPTION
First attempt to add an uberjar release to jet. Addresses #91. I combed through the clj-kondo CI scripts and I think it's this simple, but I could be mistaken. I see clj-kondo uses `borkdude.gh-release-artifact` in a bb script, and I'm not sure if that's strictly necessary. But please let me know if there's anything else to be done!