### PR TITLE
Make elisp function the same in code and text

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ put this function somewhere in your Emacs configuration, highlight a
 region, and press `M-x jet-pretty <enter>`:
 
 ``` emacs-lisp
-(defun jet ()
+(defun jet-pretty ()
   (interactive)
   (shell-command-on-region
    (region-beginning)


### PR DESCRIPTION
The text above the code snippet says to execute `M-x jetty-printer <enter>`.
But then the Elisp function shown in the code snippet is named `jet`.
We obviously we need to use the same name in both places.